### PR TITLE
Countdown before round of scenarios

### DIFF
--- a/app/app/play/page.tsx
+++ b/app/app/play/page.tsx
@@ -1,7 +1,7 @@
 import { currentUser } from '@clerk/nextjs/server';
 import { redirect } from 'next/navigation';
-import { Game } from '~/components/game/game';
 import { GameFinish } from '~/components/game/game-finish';
+import { GameLayout } from '~/components/game/game-layout';
 import { getRandom, getUnplayedScenarios } from '~/lib/db/queries';
 
 export default async function Page() {
@@ -25,5 +25,5 @@ export default async function Page() {
         redirect('/app/scores');
     }
 
-    return <Game scenario={scenario} unplayedScenarios={unplayedScenarios.length} />;
+    return <GameLayout scenario={scenario} remainingScenarios={unplayedScenarios.length} />;
 }

--- a/app/backstage/play/[scenarioId]/page.tsx
+++ b/app/backstage/play/[scenarioId]/page.tsx
@@ -1,14 +1,19 @@
 import { notFound } from 'next/navigation';
 import { getScenario } from '~/lib/db/queries';
-import { Game } from '~/components/game/game';
+import { GameLayout } from '~/components/game/game-layout';
 
-export default async function Page({ params }: { params: Promise<{ scenarioId: number }> }) {
+type Params = Promise<{ scenarioId: number }>;
+type SearchParams = Promise<{ [key: string]: string | string[] | undefined }>;
+
+export default async function Page({ params, searchParams }: { params: Params; searchParams: SearchParams }) {
     const id = (await params).scenarioId;
+    const showSolution = (await searchParams).solution === 'true';
+
     if (isNaN(id)) notFound();
 
     const scenario = await getScenario(id);
 
     if (!scenario?.data) notFound();
 
-    return <Game backstageAccess scenario={scenario} />;
+    return <GameLayout backstageAccess scenario={scenario} showSolution={showSolution} />;
 }

--- a/app/backstage/play/[scenarioId]/page.tsx
+++ b/app/backstage/play/[scenarioId]/page.tsx
@@ -15,5 +15,5 @@ export default async function Page({ params, searchParams }: { params: Params; s
 
     if (!scenario?.data) notFound();
 
-    return <GameLayout backstageAccess scenario={scenario} showSolution={showSolution} />;
+    return <GameLayout backstageAccess scenario={scenario} revealSolution={showSolution} />;
 }

--- a/components/game/game-initial-countdown.tsx
+++ b/components/game/game-initial-countdown.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useRef, useState } from 'react';
 import { CountdownCircleTimer } from 'react-countdown-circle-timer';
 import { cn } from '~/lib/utils';
 import { GAME_COUNTDOWN_DURATION } from '~/lib/constants';
@@ -10,6 +10,53 @@ const COUNTDOWN_COLOR = '#fff';
 type GameInitialCountdownProps = {
     running: boolean;
     onComplete: () => void;
+};
+
+const Time = ({ value: remainingTime }: { value: number }) => {
+    const currentTime = useRef(remainingTime);
+    const prevTime = useRef<number | null>(null);
+    const isNewTimeFirstTick = useRef(false);
+    const [, setOneLastRerender] = useState(0);
+
+    if (currentTime.current !== remainingTime) {
+        isNewTimeFirstTick.current = true;
+        prevTime.current = currentTime.current;
+        currentTime.current = remainingTime;
+    } else {
+        isNewTimeFirstTick.current = false;
+    }
+
+    // force one last re-render when the time is over to tirgger the last animation
+    if (remainingTime === 0) {
+        setTimeout(() => {
+            setOneLastRerender((val) => val + 1);
+        }, 20);
+    }
+
+    const isTimeUp = isNewTimeFirstTick.current;
+
+    return (
+        <div className="relative font-barlow text-6xl text-white">
+            <div
+                key={remainingTime}
+                className={cn(
+                    'absolute left-0 top-0 flex h-full w-full translate-y-0 items-center justify-center opacity-100 transition-all duration-300',
+                    isTimeUp && 'scale-0 opacity-0'
+                )}>
+                {remainingTime}
+            </div>
+            {prevTime.current !== null && (
+                <div
+                    key={prevTime.current}
+                    className={cn(
+                        'absolute left-0 top-0 flex h-full w-full translate-y-0 items-center justify-center opacity-100 transition-all duration-300',
+                        !isTimeUp && 'scale-[3] opacity-0'
+                    )}>
+                    {prevTime.current}
+                </div>
+            )}
+        </div>
+    );
 };
 
 export const GameInitialCountdown = (props: PropsWithChildren<GameInitialCountdownProps>) => {
@@ -26,7 +73,7 @@ export const GameInitialCountdown = (props: PropsWithChildren<GameInitialCountdo
                         strokeWidth={0}
                         trailStrokeWidth={0}
                         onComplete={props.onComplete}>
-                        {({ remainingTime }) => <div className="font-barlow text-6xl text-white">{remainingTime}</div>}
+                        {({ remainingTime }) => <Time value={remainingTime} />}
                     </CountdownCircleTimer>
                 </div>
             )}

--- a/components/game/game-initial-countdown.tsx
+++ b/components/game/game-initial-countdown.tsx
@@ -18,18 +18,16 @@ export const GameInitialCountdown = (props: PropsWithChildren<GameInitialCountdo
             <div className={cn(props.running && 'blur-md')}>{props.children}</div>
             {props.running && (
                 <div className="absolute inset-0 flex items-center justify-center">
-                    <div className="text-6xl text-white">
-                        <CountdownCircleTimer
-                            isPlaying
-                            duration={GAME_COUNTDOWN_DURATION}
-                            colors={COUNTDOWN_COLOR}
-                            trailColor={COUNTDOWN_COLOR}
-                            strokeWidth={0}
-                            trailStrokeWidth={0}
-                            onComplete={props.onComplete}>
-                            {({ remainingTime }) => remainingTime}
-                        </CountdownCircleTimer>
-                    </div>
+                    <CountdownCircleTimer
+                        isPlaying
+                        duration={GAME_COUNTDOWN_DURATION}
+                        colors={COUNTDOWN_COLOR}
+                        trailColor={COUNTDOWN_COLOR}
+                        strokeWidth={0}
+                        trailStrokeWidth={0}
+                        onComplete={props.onComplete}>
+                        {({ remainingTime }) => <div className="font-barlow text-6xl text-white">{remainingTime}</div>}
+                    </CountdownCircleTimer>
                 </div>
             )}
         </div>

--- a/components/game/game-initial-countdown.tsx
+++ b/components/game/game-initial-countdown.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { PropsWithChildren } from 'react';
+import { CountdownCircleTimer } from 'react-countdown-circle-timer';
+import { cn } from '~/lib/utils';
+import { GAME_COUNTDOWN_DURATION } from '~/lib/constants';
+
+const COUNTDOWN_COLOR = '#fff';
+
+type GameInitialCountdownProps = {
+    running: boolean;
+    onComplete: () => void;
+};
+
+export const GameInitialCountdown = (props: PropsWithChildren<GameInitialCountdownProps>) => {
+    return (
+        <div className="relative">
+            <div className={cn(props.running && 'blur-md')}>{props.children}</div>
+            {props.running && (
+                <div className="absolute inset-0 flex items-center justify-center">
+                    <div className="text-6xl text-white">
+                        <CountdownCircleTimer
+                            isPlaying
+                            duration={GAME_COUNTDOWN_DURATION}
+                            colors={COUNTDOWN_COLOR}
+                            trailColor={COUNTDOWN_COLOR}
+                            strokeWidth={0}
+                            trailStrokeWidth={0}
+                            onComplete={props.onComplete}>
+                            {({ remainingTime }) => remainingTime}
+                        </CountdownCircleTimer>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/components/game/game-layout.tsx
+++ b/components/game/game-layout.tsx
@@ -12,28 +12,16 @@ type GameLayoutProps = {
     remainingScenarios?: number;
 };
 
-const GameComponent = (props: PropsWithoutRef<GameLayoutProps & { countdownRunning: boolean }>) => {
-    return (
-        <Game
-            scenario={props.scenario}
-            showSolution={props.showSolution}
-            countdownRunning={props.countdownRunning}
-            backstageAccess={props.backstageAccess}
-            unplayedScenarios={props.remainingScenarios}
-        />
-    );
-};
-
 export const GameLayout = (props: PropsWithoutRef<GameLayoutProps>) => {
     const [countdownRunning, setCountdownRunning] = useState(!props.showSolution);
 
     if (!props.showSolution) {
         return (
             <GameInitialCountdown running={countdownRunning} onComplete={() => setCountdownRunning(false)}>
-                <GameComponent countdownRunning={countdownRunning} {...props} />
+                <Game countdownRunning={countdownRunning} {...props} />
             </GameInitialCountdown>
         );
     }
 
-    return <GameComponent countdownRunning={countdownRunning} {...props} />;
+    return <Game countdownRunning={countdownRunning} {...props} />;
 };

--- a/components/game/game-layout.tsx
+++ b/components/game/game-layout.tsx
@@ -7,15 +7,15 @@ import { Game } from '~/components/game/game';
 
 type GameLayoutProps = {
     scenario: ScenarioSelect;
-    showSolution?: boolean;
+    revealSolution?: boolean;
     backstageAccess?: boolean;
     remainingScenarios?: number;
 };
 
 export const GameLayout = (props: PropsWithoutRef<GameLayoutProps>) => {
-    const [countdownRunning, setCountdownRunning] = useState(!props.showSolution);
+    const [countdownRunning, setCountdownRunning] = useState(!props.revealSolution);
 
-    if (!props.showSolution) {
+    if (!props.revealSolution) {
         return (
             <GameInitialCountdown running={countdownRunning} onComplete={() => setCountdownRunning(false)}>
                 <Game countdownRunning={countdownRunning} {...props} />

--- a/components/game/game-layout.tsx
+++ b/components/game/game-layout.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { PropsWithoutRef, useState } from 'react';
+import { ScenarioSelect } from '~/lib/types';
+import { GameInitialCountdown } from '~/components/game/game-initial-countdown';
+import { Game } from '~/components/game/game';
+
+type GameLayoutProps = {
+    scenario: ScenarioSelect;
+    showSolution?: boolean;
+    backstageAccess?: boolean;
+    remainingScenarios?: number;
+};
+
+const GameComponent = (props: PropsWithoutRef<GameLayoutProps & { countdownRunning: boolean }>) => {
+    return (
+        <Game
+            scenario={props.scenario}
+            showSolution={props.showSolution}
+            countdownRunning={props.countdownRunning}
+            backstageAccess={props.backstageAccess}
+            unplayedScenarios={props.remainingScenarios}
+        />
+    );
+};
+
+export const GameLayout = (props: PropsWithoutRef<GameLayoutProps>) => {
+    const [countdownRunning, setCountdownRunning] = useState(!props.showSolution);
+
+    if (!props.showSolution) {
+        return (
+            <GameInitialCountdown running={countdownRunning} onComplete={() => setCountdownRunning(false)}>
+                <GameComponent countdownRunning={countdownRunning} {...props} />
+            </GameInitialCountdown>
+        );
+    }
+
+    return <GameComponent countdownRunning={countdownRunning} {...props} />;
+};

--- a/components/game/game-timer.tsx
+++ b/components/game/game-timer.tsx
@@ -20,7 +20,7 @@ const renderTime = ({ remainingTime }: { remainingTime: number }) => {
     return <div className="select-none text-2xl font-bold">{remainingTime}</div>;
 };
 
-const GameCountdown = (props: PropsWithoutRef<GameCountdownProps>) => {
+const GameTimer = (props: PropsWithoutRef<GameCountdownProps>) => {
     return (
         <div className={cn('flex items-center justify-center', props.className)}>
             <div
@@ -41,4 +41,4 @@ const GameCountdown = (props: PropsWithoutRef<GameCountdownProps>) => {
     );
 };
 
-export { GameCountdown };
+export { GameTimer };

--- a/components/game/game.tsx
+++ b/components/game/game.tsx
@@ -19,7 +19,7 @@ import Image from 'next/image';
 
 type GameProps = {
     scenario: ScenarioSelect;
-    showSolution?: boolean;
+    revealSolution?: boolean;
     countdownRunning?: boolean;
     unplayedScenarios?: number;
     backstageAccess?: boolean;
@@ -91,10 +91,10 @@ const Game = (props: PropsWithoutRef<GameProps>) => {
     }, [scenario, gameSuccess, completeGameAction, props.backstageAccess]);
 
     useEffect(() => {
-        if (scenario.data.isSolution(selectedPairs) || props.showSolution) {
+        if (scenario.data.isSolution(selectedPairs) || props.revealSolution) {
             setGameSuccess(true);
         }
-    }, [scenario, selectedPairs, props.showSolution]);
+    }, [scenario, selectedPairs, props.revealSolution]);
 
     const isClear = useCallback(
         (pair: [string, string]) => {
@@ -240,7 +240,7 @@ const Game = (props: PropsWithoutRef<GameProps>) => {
                         className="fixed left-16 top-5 z-10 transition-all hover:scale-110"
                         total={scenario.data.solution.length}
                         progress={
-                            props.showSolution
+                            props.revealSolution
                                 ? scenario.data.solution.length
                                 : scenario.data.numberCorrect(selectedPairs)
                         }
@@ -248,7 +248,7 @@ const Game = (props: PropsWithoutRef<GameProps>) => {
                     <GameTimer
                         className="fixed left-36 top-5 z-10 transition-all hover:scale-110"
                         initialCount={GAME_TIMEOUT_MS / 1000}
-                        running={!props.showSolution ? !props.countdownRunning && gameSuccess === null : false}
+                        running={!props.revealSolution ? !props.countdownRunning && gameSuccess === null : false}
                         onComplete={() => setGameSuccess(false)}
                     />
                 </>

--- a/components/game/game.tsx
+++ b/components/game/game.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { PropsWithoutRef, startTransition, useActionState, useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import posthog from 'posthog-js';
@@ -10,7 +10,7 @@ import { GAME_MAX_SCENARIOS_IN_A_ROW, GAME_TIMEOUT_MS, TIME_TO_REMOVE_FAILED_PAI
 import { Pcd } from '~/lib/domain/pcd';
 import { Scenario } from '~/lib/domain/scenario';
 import { ScenarioSelect } from '~/lib/types';
-import { GameCountdown } from '~/components/game/game-countdown';
+import { GameTimer } from '~/components/game/game-timer';
 import { IconButton } from '~/components/ui/icon-button';
 import { GameNextButton } from '~/components/game/game-next-button';
 import { GameProgress } from '~/components/game/game-progress';
@@ -19,6 +19,8 @@ import Image from 'next/image';
 
 type GameProps = {
     scenario: ScenarioSelect;
+    showSolution?: boolean;
+    countdownRunning?: boolean;
     unplayedScenarios?: number;
     backstageAccess?: boolean;
 };
@@ -30,9 +32,6 @@ const posthogEvents = {
 
 const Game = (props: PropsWithoutRef<GameProps>) => {
     const { replace } = useRouter();
-    const searchParams = useSearchParams();
-
-    const shouldShowSolution = searchParams.get('solution') === 'true';
 
     const [scenario, setScenario] = useState({
         ...props.scenario,
@@ -92,10 +91,10 @@ const Game = (props: PropsWithoutRef<GameProps>) => {
     }, [scenario, gameSuccess, completeGameAction, props.backstageAccess]);
 
     useEffect(() => {
-        if (scenario.data.isSolution(selectedPairs) || shouldShowSolution) {
+        if (scenario.data.isSolution(selectedPairs) || props.showSolution) {
             setGameSuccess(true);
         }
-    }, [scenario, selectedPairs, shouldShowSolution]);
+    }, [scenario, selectedPairs, props.showSolution]);
 
     const isClear = useCallback(
         (pair: [string, string]) => {
@@ -235,17 +234,21 @@ const Game = (props: PropsWithoutRef<GameProps>) => {
                 </>
             )}
 
-            {isMapReady && !shouldShowSolution && (
+            {isMapReady && (
                 <>
                     <GameProgress
                         className="fixed left-16 top-5 z-10 transition-all hover:scale-110"
                         total={scenario.data.solution.length}
-                        progress={scenario.data.numberCorrect(selectedPairs)}
+                        progress={
+                            props.showSolution
+                                ? scenario.data.solution.length
+                                : scenario.data.numberCorrect(selectedPairs)
+                        }
                     />
-                    <GameCountdown
+                    <GameTimer
                         className="fixed left-36 top-5 z-10 transition-all hover:scale-110"
                         initialCount={GAME_TIMEOUT_MS / 1000}
-                        running={gameSuccess === null}
+                        running={!props.showSolution ? !props.countdownRunning && gameSuccess === null : false}
                         onComplete={() => setGameSuccess(false)}
                     />
                 </>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -9,6 +9,7 @@ export const GAME_INDICATOR_STROKE_WIDTH = 6;
 export const GAME_INDICATOR_TRAIL_STROKE_WIDTH = 2;
 export const GAME_TIMEOUT_MS = 30_000;
 export const GAME_MAX_SCENARIOS_IN_A_ROW = 5;
+export const GAME_COUNTDOWN_DURATION = 3;
 
 export const MAP_SOURCE_ID = 'scenario-source';
 


### PR DESCRIPTION
<!-- List of issues resolved/canceled as a result of this PR
resolves #
fixes #
closes #
-->

resolves #328 

How to try:

<!-- Instructions so that how a reviewer can try this locally
     Example:

     1. Navigate to the changed page
     1. Perform whatever action is required
     1. Validate that the output/user experience is as expected
-->

1. Start playing a scenario and you should see a 3,2,1 countdown and the map in the background with a blur effect.
2. Check also the access to the scenarios from the backstage scenarios table, either to play or to reveal the solution. In this last case, there should be no countdown.





